### PR TITLE
Changed intent slot type

### DIFF
--- a/intent_schema.json
+++ b/intent_schema.json
@@ -4,7 +4,7 @@
       "slots": [
         {
           "name": "query",
-          "type": "AMAZON.LITERAL"
+          "type": "AMAZON.SearchQuery"
         }
       ],
       "intent": "callSusiApi"


### PR DESCRIPTION
Fixes issue #20

Changes:
AMAZON.LITERAL slot type is retired. After October 22, 2018, new and updated skills are no longer be able to use AMAZON.LITERAL. If a skill was published that uses AMAZON.LITERAL, customers will still be able to use it. Any updates made to a skill after October 22 will require you to replace AMAZON.LITERAL. Also since AMAZON.LITERAL didn't support Indian, UK and CA language, this change is required. This change itself is a pretty interesting one as it is much more user friendly and more improved in terms of recognition of common words or phrases. 

Refer this for better clarity on AMAZON.SearchQuery: https://developer.amazon.com/blogs/alexa/post/a2716002-0f50-4587-b038-31ce631c0c07/enhance-speech-recognition-of-your-alexa-skills-with-phrase-slots-and-amazon-searchquery
